### PR TITLE
add missing requiresAuthentication field to NFC object

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -479,8 +479,9 @@ func (a *PWAssociatedApp) GetValidationErrors() []string {
 }
 
 type NFC struct {
-	Message             string `json:"message,omitempty"`
-	EncryptionPublicKey string `json:"encryptionPublicKey,omitempty"`
+	Message                string `json:"message,omitempty"`
+	EncryptionPublicKey    string `json:"encryptionPublicKey,omitempty"`
+	RequiresAuthentication bool   `json:"requiresAuthentication,omitempty"`
 }
 
 type Personalization struct {


### PR DESCRIPTION
This PR adds "requiresAuthentication" to NFC object, as documented in https://developer.apple.com/documentation/walletpasses/pass/nfc