### PR TITLE
Use a copy of the files when signing with a `memorySigner`

### DIFF
--- a/mem_signer.go
+++ b/mem_signer.go
@@ -21,10 +21,11 @@ func (m *memorySigner) CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate,
 }
 
 func (m *memorySigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) ([]byte, error) {
-	files, err := t.GetAllFiles()
+	originalFiles, err := t.GetAllFiles()
 	if err != nil {
 		return nil, err
 	}
+	files := m.makeFilesCopy(originalFiles)
 
 	if !p.IsValid() {
 		return nil, fmt.Errorf("%v", p.GetValidationErrors())
@@ -107,4 +108,13 @@ func (m *memorySigner) createZipFile(files map[string][]byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func (m *memorySigner) makeFilesCopy(files map[string][]byte) map[string][]byte {
+	filesCopy := make(map[string][]byte, len(files))
+	for k := range files {
+		filesCopy[k] = files[k]
+	}
+
+	return filesCopy
 }


### PR DESCRIPTION
I've found that when using a `memorySigner`, the original files from the template get corrupted in subsequent calls to the `CreateSignedAndZippedPersonalizedPassArchive` method. I think that similar to the `fileSigner` implementation, the `memorySigner` one should work with a temporary copy of the template files and not affect the original ones. Once the pass is signed and compressed, the temporary copy should be removed, as the `fileSigner` does.

Given that in Go the maps are passed by reference and not by value, the `CreateSignedAndZippedPersonalizedPassArchive` method is propagating the `manifest.json` and `signature` files calculated in a first call, to the subsequent calls. For example, in a first call, it correctly generates the following `manifest.json` file and a valid Apple Wallet pass:

```json
{
    "footer.png": "ec95fabe4c282cf0c5acdbc3d58d2adeb2847385",
    "icon.png": "cf6a2cd30798d472f0cb81364d25ba6e895b0cae",
    "icon@2x-.png": "3915ac1b648893731acdd6f53c28cf1179bb72bc",
    "logo.png": "0b9c6f6022ef1031d031cae2f7541173d9039504",
    "pass.json": "cc7095122351b0abdc6724bf4d0dc8a2b582a799"
}
```

However, In a second call, the `manifest.json` file would have these extra entries that make the generated pass to be corrupted:

```json
{
    ...
    "manifest.json": "e82e8d958daa0d967c68897e00bf78bd884d1b1a",
    "signature": "ae8f34675a2f5a45a763e221bc8f9c54dc505548"
}
```

This PR makes a deep copy of the template files and lets the GC deal with removing the copy once the signing/compressing of the files is completed and the copy is not referenced anymore.