### PR TITLE
Support the row property for auxiliary fields

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -350,6 +350,7 @@ type Field struct {
 	TimeStyle         DateStyle          `json:"timeStyle,omitempty"`
 	IsRelative        bool               `json:"isRelative,omitempty"`
 	IgnoreTimeZone    bool               `json:"ignoresTimeZone,omitempty"`
+	Row               int                `json:"row,omitempty"`
 }
 
 func (f *Field) IsValid() bool {
@@ -403,6 +404,10 @@ func (f *Field) GetValidationErrors() []string {
 		default:
 			validationErrors = append(validationErrors, "When using currencies, the values have to be numbers")
 		}
+	}
+
+	if f.Row != 0 && f.Row != 1 {
+		validationErrors = append(validationErrors, "Row must be 0 or 1")
 	}
 
 	return validationErrors


### PR DESCRIPTION
Apple allows adding a second row of Auxiliary fields in the front of the Apple Wallet passes via the `row` property in the `PassFields.AuxiliaryFields` object. The `row` property defines the row in which the auxiliary fields are displayed. A single row is displayed by default if the `row` property is absent. However, if it's present with a value of `1`, the fields with `row: 0`, or that lack the property, will be displayed in the first row, and those with `row: 1` in the second.

This is the definition from the [PassFields.AuxiliaryFields documentation](https://developer.apple.com/documentation/walletpasses/passfields/auxiliaryfields):
>row | number: A number you use to add a row to the auxiliary field in an event ticket pass type. Set the value to 1 to add an auxiliary row. Each row displays up to four fields.

This PR adds the `Row` property to the `Field` struct and adds an extra check in the `GetValidationErrors` validation to verify it's either 0 or 1. It uses the `omitempty` tag to avoid defining it in the output JSON if it's 0, which helps to avoid defining it on fields that are not Auxiliary fields.

This is how two Auxiliary field rows are displayed on a pass:

![image](https://github.com/alvinbaena/passkit/assets/691521/cf885cea-a03f-4224-8477-b34cd4313b41)