### PR TITLE
Replace fullsailor/pkcs7 with go.mozilla.org/pkcs7 to fix "Signature must contain a signing date" issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alvinbaena/passkit
 go 1.17
 
 require (
-	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
+	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7
 	gopkg.in/go-playground/colors.v1 v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa h1:RDBNVkRviHZtvDvId8XSGPu3rmpmSe+wKRcEWNgsfWU=
-github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
+go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=
+go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7 h1:WJywXQVIb56P2kAvXeMGTIgQ1ZHQxR60+F9dLsodECc=
 golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/signing.go
+++ b/signing.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"go.mozilla.org/pkcs7"
 	"golang.org/x/crypto/pkcs12"
@@ -106,17 +105,9 @@ func signManifestFile(manifestJson []byte, i *SigningInformation) ([]byte, error
 		return nil, err
 	}
 
-	signerInfoConfig := pkcs7.SignerInfoConfig{
-		ExtraSignedAttributes: []pkcs7.Attribute{
-			{
-				Type:  pkcs7.OIDAttributeSigningTime,
-				Value: time.Now(),
-			},
-		},
-	}
-
 	s.AddCertificate(i.appleWWDRCACert)
-	err = s.AddSigner(i.signingCert, i.privateKey, signerInfoConfig)
+
+	err = s.AddSigner(i.signingCert, i.privateKey, pkcs7.SignerInfoConfig{})
 	if err != nil {
 		return nil, err
 	}

--- a/signing.go
+++ b/signing.go
@@ -4,9 +4,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/fullsailor/pkcs7"
-	"golang.org/x/crypto/pkcs12"
 	"os"
+	"time"
+
+	"go.mozilla.org/pkcs7"
+	"golang.org/x/crypto/pkcs12"
 )
 
 const (
@@ -104,8 +106,17 @@ func signManifestFile(manifestJson []byte, i *SigningInformation) ([]byte, error
 		return nil, err
 	}
 
+	signerInfoConfig := pkcs7.SignerInfoConfig{
+		ExtraSignedAttributes: []pkcs7.Attribute{
+			{
+				Type:  pkcs7.OIDAttributeSigningTime,
+				Value: time.Now(),
+			},
+		},
+	}
+
 	s.AddCertificate(i.appleWWDRCACert)
-	err = s.AddSigner(i.signingCert, i.privateKey, pkcs7.SignerInfoConfig{})
+	err = s.AddSigner(i.signingCert, i.privateKey, signerInfoConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR addresses the **"Invalid data error reading pass xxx. Signature must contain a signing date"** issue by replacing the PKCS#7 library from `github.com/fullsailor/pkcs7` to `go.mozilla.org/pkcs7`.

### Changes:
- Updated the PKCS#7 library to `go.mozilla.org/pkcs7`

### Why this change:
The older PKCS#7 library did not include the signing date in the signature, causing passes to be considered invalid on iOS devices. This change resolves that issue.

### Testing:
- Tested locally and verified that the "Signature must contain a signing date" issue is resolved.
