### PR TITLE
fix: remove altText from required field

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -502,7 +502,7 @@ func (b *Barcode) IsValid() bool {
 func (b *Barcode) GetValidationErrors() []string {
 	var validationErrors []string
 
-	if string(b.Format) == "" || strings.TrimSpace(b.Message) == "" || strings.TrimSpace(b.MessageEncoding) == "" || strings.TrimSpace(b.AltText) == "" {
+	if string(b.Format) == "" || strings.TrimSpace(b.Message) == "" || strings.TrimSpace(b.MessageEncoding) == "" {
 		validationErrors = append(validationErrors, fmt.Sprintf("Barcode: Not all required Fields are set. Format: %v, Message: %v, MessageEncoding: %v, AltText: %v", b.Format, b.Message, b.MessageEncoding, b.AltText))
 	}
 


### PR DESCRIPTION
based on official doc, altText should not be a required field for barcode
ref: https://developer.apple.com/documentation/walletpasses/pass/barcodes#properties