### PR TITLE
Support `relevantDates` field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/alvinbaena/passkit
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.17
 
 require (
-	go.mozilla.org/pkcs7 v0.9.0
+	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	gopkg.in/go-playground/colors.v1 v1.2.0
-	software.sslmate.com/src/go-pkcs12 v0.5.0
+	software.sslmate.com/src/go-pkcs12 v0.4.0
 )
 
-require golang.org/x/crypto v0.39.0 // indirect
+require golang.org/x/crypto v0.38.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/alvinbaena/passkit
 
-go 1.17
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
-	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
+	go.mozilla.org/pkcs7 v0.9.0
 	gopkg.in/go-playground/colors.v1 v1.2.0
-	software.sslmate.com/src/go-pkcs12 v0.4.0
+	software.sslmate.com/src/go-pkcs12 v0.5.0
 )
 
-require golang.org/x/crypto v0.38.0 // indirect
+require golang.org/x/crypto v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDf
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDf
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
-golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
-golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/pass.go
+++ b/pass.go
@@ -574,7 +574,7 @@ type PassRelevantDate struct {
 	EndDate   *time.Time
 }
 
-func (prd *PassRelevantDate) toJSON() ([]byte, error) {
+func (prd PassRelevantDate) MarshalJSON() ([]byte, error) {
 	if prd.EndDate != nil {
 		return json.Marshal(&struct {
 			StartDate *time.Time `json:"startDate"`

--- a/pass.go
+++ b/pass.go
@@ -605,3 +605,20 @@ func (prd *PassRelevantDate) GetValidationErrors() []string {
 
 	return validationErrors
 }
+
+func (p *Pass) SetRelevantDates(d []PassRelevantDate) {
+
+	if len(d) == 0 {
+		return
+	}
+	minDate := d[0].StartDate
+
+	for _, pdr := range d {
+		if pdr.StartDate.Before(*minDate) {
+			minDate = pdr.StartDate
+		}
+	}
+
+	p.RelevantDates = d
+	p.RelevantDate = minDate
+}

--- a/pass_test.go
+++ b/pass_test.go
@@ -23,7 +23,7 @@ func TestPassRelevantDate_Invalid(t *testing.T) {
 }
 
 func TestPassRelevantDate_JSONMarshallingSingleDate(t *testing.T) {
-	unixTimeUTC := time.Unix(1405544146, 0)
+	unixTimeUTC := time.Date(2025, time.June, 19, 01, 23, 45, 0, time.UTC)
 	prd := PassRelevantDate{StartDate: (*time.Time)(&unixTimeUTC)}
 
 	prdJSON, err := prd.toJSON()
@@ -33,14 +33,14 @@ func TestPassRelevantDate_JSONMarshallingSingleDate(t *testing.T) {
 	}
 
 	prdJSONString := string(prdJSON)
-	expected := "{\"relevantDate\":\"2014-07-16T21:55:46+01:00\"}"
+	expected := "{\"relevantDate\":\"2025-06-19T01:23:45Z\"}"
 	if prdJSONString != expected {
 		t.Errorf("PassRelevantDate JSON did not matched expected format")
 	}
 }
 
 func TestPassRelevantDate_JSONMarshallingDateRange(t *testing.T) {
-	unixTimeUTC := time.Unix(1405544146, 0)
+	unixTimeUTC := time.Date(2025, time.June, 19, 01, 23, 45, 0, time.UTC)
 	prd := PassRelevantDate{StartDate: (*time.Time)(&unixTimeUTC), EndDate: (*time.Time)(&unixTimeUTC)}
 
 	prdJSON, err := prd.toJSON()
@@ -50,7 +50,7 @@ func TestPassRelevantDate_JSONMarshallingDateRange(t *testing.T) {
 	}
 
 	prdJSONString := string(prdJSON)
-	expected := "{\"startDate\":\"2014-07-16T21:55:46+01:00\",\"endDate\":\"2014-07-16T21:55:46+01:00\"}"
+	expected := "{\"startDate\":\"2025-06-19T01:23:45Z\",\"endDate\":\"2025-06-19T01:23:45Z\"}"
 	if prdJSONString != expected {
 		t.Errorf("PassRelevantDate JSON did not matched expected format")
 	}
@@ -1053,5 +1053,23 @@ func TestPWAssociatedApp_GetSet(t *testing.T) {
 
 	if len(pw.GetValidationErrors()) != 0 {
 		t.Errorf("PWAssociatedApp should have no errors. Have: %v", len(pw.GetValidationErrors()))
+	}
+}
+
+func TestSetRelevantDates(t *testing.T) {
+	pass := getBasicPass()
+
+	earlyDate := time.Date(2025, time.June, 19, 01, 23, 45, 0, time.UTC)
+	pdr := getBasicRelevantDate()
+	earlierPDR := PassRelevantDate{StartDate: (*time.Time)(&earlyDate)}
+
+	var dates []PassRelevantDate
+
+	dates = append(dates, pdr)
+	dates = append(dates, earlierPDR)
+	pass.SetRelevantDates(dates)
+
+	if pass.RelevantDate != &earlyDate {
+		t.Error("relevantDate was not set to earliest date within slice")
 	}
 }

--- a/pass_test.go
+++ b/pass_test.go
@@ -26,7 +26,7 @@ func TestPassRelevantDate_JSONMarshallingSingleDate(t *testing.T) {
 	unixTimeUTC := time.Date(2025, time.June, 19, 01, 23, 45, 0, time.UTC)
 	prd := PassRelevantDate{StartDate: (*time.Time)(&unixTimeUTC)}
 
-	prdJSON, err := prd.toJSON()
+	prdJSON, err := prd.MarshalJSON()
 
 	if err != nil {
 		t.Errorf("PassRelevantDate JSON Marshalling failed. Reason %v", err)
@@ -43,7 +43,7 @@ func TestPassRelevantDate_JSONMarshallingDateRange(t *testing.T) {
 	unixTimeUTC := time.Date(2025, time.June, 19, 01, 23, 45, 0, time.UTC)
 	prd := PassRelevantDate{StartDate: (*time.Time)(&unixTimeUTC), EndDate: (*time.Time)(&unixTimeUTC)}
 
-	prdJSON, err := prd.toJSON()
+	prdJSON, err := prd.MarshalJSON()
 
 	if err != nil {
 		t.Errorf("PassRelevantDate JSON Marshalling failed. Reason %v", err)

--- a/pass_test.go
+++ b/pass_test.go
@@ -5,6 +5,57 @@ import (
 	"time"
 )
 
+func getBasicRelevantDate() PassRelevantDate {
+	t := time.Now()
+	return PassRelevantDate{StartDate: (*time.Time)(&t)}
+}
+
+func TestPassRelevantDate_Invalid(t *testing.T) {
+	prd := new(PassRelevantDate)
+
+	if prd.IsValid() {
+		t.Errorf("PassRelevantDate should be invalid")
+	}
+
+	if len(prd.GetValidationErrors()) == 0 {
+		t.Errorf("PassRelevantDate should have errors")
+	}
+}
+
+func TestPassRelevantDate_JSONMarshallingSingleDate(t *testing.T) {
+	unixTimeUTC := time.Unix(1405544146, 0)
+	prd := PassRelevantDate{StartDate: (*time.Time)(&unixTimeUTC)}
+
+	prdJSON, err := prd.toJSON()
+
+	if err != nil {
+		t.Errorf("PassRelevantDate JSON Marshalling failed. Reason %v", err)
+	}
+
+	prdJSONString := string(prdJSON)
+	expected := "{\"relevantDate\":\"2014-07-16T21:55:46+01:00\"}"
+	if prdJSONString != expected {
+		t.Errorf("PassRelevantDate JSON did not matched expected format")
+	}
+}
+
+func TestPassRelevantDate_JSONMarshallingDateRange(t *testing.T) {
+	unixTimeUTC := time.Unix(1405544146, 0)
+	prd := PassRelevantDate{StartDate: (*time.Time)(&unixTimeUTC), EndDate: (*time.Time)(&unixTimeUTC)}
+
+	prdJSON, err := prd.toJSON()
+
+	if err != nil {
+		t.Errorf("PassRelevantDate JSON Marshalling failed. Reason %v", err)
+	}
+
+	prdJSONString := string(prdJSON)
+	expected := "{\"startDate\":\"2014-07-16T21:55:46+01:00\",\"endDate\":\"2014-07-16T21:55:46+01:00\"}"
+	if prdJSONString != expected {
+		t.Errorf("PassRelevantDate JSON did not matched expected format")
+	}
+}
+
 func getBasicPersonalization() Personalization {
 	return Personalization{
 		Description:        "Description for pass",


### PR DESCRIPTION
This PR adds support for the [`relevantDates`](https://developer.apple.com/documentation/passkit/pkpass/relevantdates) property on PKPass, introduced in iOS 18.0.

I've based the JSON structure as used here https://github.com/alexandercerutti/passkit-generator/wiki/API-Documentation-Reference#setrelevantdates and tried to keep the code matching the style already established. I'm unable to run the tests as is though, without upgrading the project to Go 1.23. The `crypto` package v0.38.0 now requires this, but I didn't want to wholesale change the minimum Go version as part of this PR. Although the `relevantDate` field is now considered deprecated, I have kept it here for backwards compatibility, with  `SetRelevantDates` being a function to set both fields