### PR TITLE
Add the ability to create a bundle of passes

### DIFF
--- a/file_signer.go
+++ b/file_signer.go
@@ -17,11 +17,11 @@ func NewFileBasedSigner() Signer {
 	return &fileSigner{}
 }
 
-func (f *fileSigner) CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate, i *SigningInformation) ([]byte, error) {
+func (f *fileSigner) CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate, i *SigningInformation) (PassArchive, error) {
 	return f.CreateSignedAndZippedPersonalizedPassArchive(p, nil, t, i)
 }
 
-func (f *fileSigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) ([]byte, error) {
+func (f *fileSigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) (PassArchive, error) {
 	dir, err := os.MkdirTemp("", "pass")
 	if err != nil {
 		return nil, err
@@ -63,6 +63,39 @@ func (f *fileSigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *P
 
 	//Fail silently
 	_ = os.RemoveAll(dir)
+	return z, nil
+}
+
+func (f *fileSigner) CreatePassBundleArchive(passArchives ...PassArchive) (PassBundleArchive, error) {
+	if len(passArchives) == 0 {
+		return nil, fmt.Errorf("pass bundle must contain at least one pass")
+	}
+	if len(passArchives) > maxPassesPerBundle {
+		return nil, fmt.Errorf("pass bundle must not contain more than %d passes", maxPassesPerBundle)
+	}
+
+	dir, err := os.MkdirTemp("", "passbundle")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	for idx, pa := range passArchives {
+		filename := filepath.Join(dir, fmt.Sprintf("pass%d.pkpass", idx+1))
+		if err := os.WriteFile(filename, pa, 0644); err != nil {
+			return nil, err
+		}
+	}
+
+	z, err := f.createZipFile(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(z) > maxBundleSizeBytes {
+		return nil, fmt.Errorf("pass bundle exceeds the maximum size of 150 MB")
+	}
+
 	return z, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/alvinbaena/passkit
 
-go 1.23.0
+go 1.25.0
 
 require (
 	go.mozilla.org/pkcs7 v0.9.0
+	golang.org/x/crypto v0.50.0
 	gopkg.in/go-playground/colors.v1 v1.2.0
-	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
-
-require golang.org/x/crypto v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 go.mozilla.org/pkcs7 v0.9.0 h1:yM4/HS9dYv7ri2biPtxt8ikvB37a980dg69/pKmS+eI=
 go.mozilla.org/pkcs7 v0.9.0/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
-golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 gopkg.in/go-playground/colors.v1 v1.2.0 h1:SPweMUve+ywPrfwao+UvfD5Ah78aOLUkT5RlJiZn52c=
 gopkg.in/go-playground/colors.v1 v1.2.0/go.mod h1:AvbqcMpNXVl5gBrM20jBm3VjjKBbH/kI5UnqjU7lxFI=
-software.sslmate.com/src/go-pkcs12 v0.6.0 h1:f3sQittAeF+pao32Vb+mkli+ZyT+VwKaD014qFGq6oU=
-software.sslmate.com/src/go-pkcs12 v0.6.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/mem_signer.go
+++ b/mem_signer.go
@@ -15,11 +15,11 @@ func NewMemoryBasedSigner() Signer {
 	return &memorySigner{}
 }
 
-func (m *memorySigner) CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate, i *SigningInformation) ([]byte, error) {
+func (m *memorySigner) CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate, i *SigningInformation) (PassArchive, error) {
 	return m.CreateSignedAndZippedPersonalizedPassArchive(p, nil, t, i)
 }
 
-func (m *memorySigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) ([]byte, error) {
+func (m *memorySigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) (PassArchive, error) {
 	originalFiles, err := t.GetAllFiles()
 	if err != nil {
 		return nil, err
@@ -75,6 +75,39 @@ func (m *memorySigner) CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz 
 	}
 
 	return z, nil
+}
+
+func (m *memorySigner) CreatePassBundleArchive(passArchives ...PassArchive) (PassBundleArchive, error) {
+	if len(passArchives) == 0 {
+		return nil, fmt.Errorf("pass bundle must contain at least one pass")
+	}
+	if len(passArchives) > maxPassesPerBundle {
+		return nil, fmt.Errorf("pass bundle must not contain more than %d passes", maxPassesPerBundle)
+	}
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+
+	for idx, pa := range passArchives {
+		f, err := w.Create(fmt.Sprintf("pass%d.pkpass", idx+1))
+		if err != nil {
+			return nil, err
+		}
+		if _, err := f.Write(pa); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
+	bundleBytes := buf.Bytes()
+	if len(bundleBytes) > maxBundleSizeBytes {
+		return nil, fmt.Errorf("pass bundle exceeds the maximum size of 150 MB")
+	}
+
+	return bundleBytes, nil
 }
 
 func (m *memorySigner) SignManifestFile(manifestJson []byte, i *SigningInformation) ([]byte, error) {

--- a/signing.go
+++ b/signing.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"go.mozilla.org/pkcs7"
-	"software.sslmate.com/src/go-pkcs12"
+	"golang.org/x/crypto/pkcs12"
 )
 
 const (

--- a/signing.go
+++ b/signing.go
@@ -17,11 +17,18 @@ const (
 	passJsonFileName            = "pass.json"
 	personalizationJsonFileName = "personalization.json"
 	signatureFileName           = "signature"
+
+	maxPassesPerBundle = 10
+	maxBundleSizeBytes = 150 * 1024 * 1024 // 150 MB
 )
 
+type PassArchive []byte
+type PassBundleArchive []byte
+
 type Signer interface {
-	CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate, i *SigningInformation) ([]byte, error)
-	CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) ([]byte, error)
+	CreateSignedAndZippedPassArchive(p *Pass, t PassTemplate, i *SigningInformation) (PassArchive, error)
+	CreateSignedAndZippedPersonalizedPassArchive(p *Pass, pz *Personalization, t PassTemplate, i *SigningInformation) (PassArchive, error)
+	CreatePassBundleArchive(passArchives ...PassArchive) (PassBundleArchive, error)
 	SignManifestFile(manifestJson []byte, i *SigningInformation) ([]byte, error)
 }
 


### PR DESCRIPTION
This PR allows the creation of a "bundle of passes". Which is nothing more then a zipped collection of already signed passes.

See Apple documentation for more information:
https://developer.apple.com/documentation/walletpasses/distributing-and-updating-a-pass#Create-a-bundle-of-passes