### PR TITLE
Make InMemoryPassTemplate safe for concurrent use

### DIFF
--- a/mem_signer_test.go
+++ b/mem_signer_test.go
@@ -1,1 +1,67 @@
 package passkit
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestMemorySigner_ConcurrentSignAndTemplateMutation(t *testing.T) {
+	signingInfo, err := LoadSigningInformationFromFiles(filepath.Join("test", "passbook", "passkit.p12"), "password", filepath.Join("test", "passbook", "ca.pem"))
+	if err != nil {
+		t.Fatalf("could not load signing information. %v", err)
+	}
+
+	template := NewInMemoryPassTemplate()
+	template.AddFileBytes(BundleIcon, []byte("icon"))
+
+	pass := &Pass{
+		FormatVersion:      1,
+		SerialNumber:       "1234",
+		PassTypeIdentifier: "pass.test.concurrency",
+		TeamIdentifier:     "TEAMID",
+		Description:        "concurrency regression test",
+		OrganizationName:   "test org",
+		Generic:            NewGenericPass(),
+	}
+	if !pass.IsValid() {
+		t.Fatalf("test pass is not valid. %v", pass.GetValidationErrors())
+	}
+
+	signer := NewMemoryBasedSigner()
+
+	const (
+		workers    = 4
+		iterations = 25
+	)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(2)
+
+		go func(n int) {
+			defer wg.Done()
+			for j := range iterations {
+				template.AddFileBytes(fmt.Sprintf("file-%d-%d.png", n, j), []byte("data"))
+			}
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				z, err := signer.CreateSignedAndZippedPassArchive(pass, template, signingInfo)
+				if err != nil {
+					t.Errorf("could not sign pass. %v", err)
+					return
+				}
+				if len(z) == 0 {
+					t.Error("signed pass archive is empty")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/templates.go
+++ b/templates.go
@@ -2,11 +2,13 @@ package passkit
 
 import (
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -75,6 +77,7 @@ func (f *FolderPassTemplate) GetAllFiles() (map[string][]byte, error) {
 }
 
 type InMemoryPassTemplate struct {
+	mu    sync.RWMutex
 	files map[string][]byte
 }
 
@@ -95,7 +98,7 @@ func (m *InMemoryPassTemplate) ProvisionPassAtDirectory(tmpDirPath string) error
 		return err
 	}
 
-	for file, d := range m.files {
+	for file, d := range m.copyOfFiles() {
 		// Convert forward slashes to OS-specific path separators for file system operations.
 		osPath := filepath.FromSlash(file)
 		fullPath := filepath.Join(dst, osPath)
@@ -120,14 +123,18 @@ func (m *InMemoryPassTemplate) ProvisionPassAtDirectory(tmpDirPath string) error
 }
 
 func (m *InMemoryPassTemplate) GetAllFiles() (map[string][]byte, error) {
-	return m.files, nil
+	return m.copyOfFiles(), nil
 }
 
 func (m *InMemoryPassTemplate) AddFileBytes(name string, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.files[name] = data
 }
 
 func (m *InMemoryPassTemplate) AddFileBytesLocalized(name, locale string, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.files[m.pathForLocale(name, locale)] = data
 }
 
@@ -159,6 +166,8 @@ func (m *InMemoryPassTemplate) AddFileFromURL(name string, u url.URL) error {
 		return err
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.files[name] = b
 	return nil
 }
@@ -169,6 +178,8 @@ func (m *InMemoryPassTemplate) AddFileFromURLLocalized(name, locale string, u ur
 		return err
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.files[m.pathForLocale(name, locale)] = b
 	return nil
 }
@@ -180,9 +191,9 @@ func (m *InMemoryPassTemplate) AddAllFiles(directoryWithFilesToAdd string) error
 		return err
 	}
 
-	for name, data := range loaded {
-		m.files[name] = data
-	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	maps.Copy(m.files, loaded)
 
 	return nil
 }
@@ -193,4 +204,14 @@ func (m *InMemoryPassTemplate) pathForLocale(name string, locale string) string 
 	}
 
 	return filepath.Join(locale+".lproj", name)
+}
+
+func (m *InMemoryPassTemplate) copyOfFiles() map[string][]byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	files := make(map[string][]byte, len(m.files))
+	maps.Copy(files, m.files)
+
+	return files
 }

--- a/templates.go
+++ b/templates.go
@@ -90,9 +90,9 @@ func (m *InMemoryPassTemplate) ProvisionPassAtDirectory(tmpDirPath string) error
 		return err
 	}
 
-	err = os.MkdirAll(dst, os.ModeDir)
+	err = os.MkdirAll(dst, 0700)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	for file, d := range m.files {

--- a/templates_test.go
+++ b/templates_test.go
@@ -1,0 +1,128 @@
+package passkit
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestInMemoryPassTemplate_ConcurrentAccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("remote file data"))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("could not parse test server url. %v", err)
+	}
+
+	template := NewInMemoryPassTemplate()
+
+	const (
+		workers    = 4
+		iterations = 50
+	)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(6)
+
+		go func(n int) {
+			defer wg.Done()
+			for j := range iterations {
+				template.AddFileBytes(fmt.Sprintf("file-%d-%d.png", n, j), []byte("data"))
+			}
+		}(i)
+
+		go func(n int) {
+			defer wg.Done()
+			for j := range iterations {
+				template.AddFileBytesLocalized(fmt.Sprintf("file-%d-%d.strings", n, j), "en", []byte("data"))
+			}
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if err := template.AddFileFromURL(BundleIcon, *u); err != nil {
+					t.Errorf("could not add file from url. %v", err)
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if err := template.AddAllFiles(filepath.Join("test", "StoreCard.raw")); err != nil {
+					t.Errorf("could not add all files. %v", err)
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				files, err := template.GetAllFiles()
+				if err != nil {
+					t.Errorf("could not get all files. %v", err)
+					return
+				}
+				for name := range files {
+					if len(name) == 0 {
+						t.Error("unexpected empty template entry name")
+						return
+					}
+				}
+			}
+		}()
+
+		go func(n int) {
+			defer wg.Done()
+			base := t.TempDir()
+			for j := range 10 {
+				dir := filepath.Join(base, fmt.Sprintf("pass-%d-%d", n, j))
+				if err := template.ProvisionPassAtDirectory(dir); err != nil {
+					t.Errorf("could not provision pass at directory. %v", err)
+					return
+				}
+				_ = os.RemoveAll(dir)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestInMemoryPassTemplate_GetAllFilesReturnsSnapshot(t *testing.T) {
+	template := NewInMemoryPassTemplate()
+	template.AddFileBytes(BundleIcon, []byte("icon"))
+
+	files, err := template.GetAllFiles()
+	if err != nil {
+		t.Fatalf("could not get all files. %v", err)
+	}
+
+	files["injected.png"] = []byte("injected")
+	template.AddFileBytes(BundleLogo, []byte("logo"))
+
+	current, err := template.GetAllFiles()
+	if err != nil {
+		t.Fatalf("could not get all files. %v", err)
+	}
+
+	if _, ok := current["injected.png"]; ok {
+		t.Error("mutating the map returned by GetAllFiles should not affect the template")
+	}
+
+	if _, ok := files[BundleLogo]; ok {
+		t.Error("files added after GetAllFiles should not show up in a previously returned map")
+	}
+}


### PR DESCRIPTION
This PR fixes the race conditions reported in #24. It adds a mutex to `InMemoryPassTemplate` and makes `GetAllFiles` return a copy of the internal map, so signing passes while other goroutines add files no longer crashes with "concurrent map iteration and map write". 

It also fixes `ProvisionPassAtDirectory`, which was creating the destination directory with `os.ModeDir` (no permission bits, so all writes into it failed) and was ignoring the error.

Regression tests are included and run with the race detector enabled in CI.