### PR TITLE
Switch back to sslmate go-pkcs12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/alvinbaena/passkit
 go 1.25.0
 
 require (
-	go.mozilla.org/pkcs7 v0.9.0
+	go.mozilla.org/pkcs7 v0.10.0
 	gopkg.in/go-playground/colors.v1 v1.2.0
-	software.sslmate.com/src/go-pkcs12 v0.6.0
+	software.sslmate.com/src/go-pkcs12 v0.7.3
 )
 
-require golang.org/x/crypto v0.38.0 // indirect
+require golang.org/x/crypto v0.55.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.25.0
 
 require (
 	go.mozilla.org/pkcs7 v0.9.0
-	golang.org/x/crypto v0.54.0
 	gopkg.in/go-playground/colors.v1 v1.2.0
+	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
+
+require golang.org/x/crypto v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 go.mozilla.org/pkcs7 v0.9.0 h1:yM4/HS9dYv7ri2biPtxt8ikvB37a980dg69/pKmS+eI=
 go.mozilla.org/pkcs7 v0.9.0/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
-golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
-golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
-golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 gopkg.in/go-playground/colors.v1 v1.2.0 h1:SPweMUve+ywPrfwao+UvfD5Ah78aOLUkT5RlJiZn52c=
 gopkg.in/go-playground/colors.v1 v1.2.0/go.mod h1:AvbqcMpNXVl5gBrM20jBm3VjjKBbH/kI5UnqjU7lxFI=
+software.sslmate.com/src/go-pkcs12 v0.6.0 h1:f3sQittAeF+pao32Vb+mkli+ZyT+VwKaD014qFGq6oU=
+software.sslmate.com/src/go-pkcs12 v0.6.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
 go.mozilla.org/pkcs7 v0.9.0 h1:yM4/HS9dYv7ri2biPtxt8ikvB37a980dg69/pKmS+eI=
 go.mozilla.org/pkcs7 v0.9.0/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
+go.mozilla.org/pkcs7 v0.10.0 h1:jmljzDzNYFzaP1dFlgmCiQml9e+iEMmv8/NNs4evQbg=
+go.mozilla.org/pkcs7 v0.10.0/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 gopkg.in/go-playground/colors.v1 v1.2.0 h1:SPweMUve+ywPrfwao+UvfD5Ah78aOLUkT5RlJiZn52c=
 gopkg.in/go-playground/colors.v1 v1.2.0/go.mod h1:AvbqcMpNXVl5gBrM20jBm3VjjKBbH/kI5UnqjU7lxFI=
 software.sslmate.com/src/go-pkcs12 v0.6.0 h1:f3sQittAeF+pao32Vb+mkli+ZyT+VwKaD014qFGq6oU=
 software.sslmate.com/src/go-pkcs12 v0.6.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+software.sslmate.com/src/go-pkcs12 v0.7.3 h1:JBQD3FDqYjTeyDAeZQklj2ar88ykBLtALloPJHyAauU=
+software.sslmate.com/src/go-pkcs12 v0.7.3/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/signing.go
+++ b/signing.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"go.mozilla.org/pkcs7"
-	"golang.org/x/crypto/pkcs12"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 const (

--- a/signing_test.go
+++ b/signing_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 func TestSigner_LoadSigningInformationFromFiles(t *testing.T) {
@@ -44,5 +46,40 @@ func TestSigner_ValidCerts(t *testing.T) {
 	_, err := LoadSigningInformationFromFiles(filepath.Join("test", "passbook", "passkit.p12"), "password", filepath.Join("test", "passbook", "ca-chain.cert.pem"))
 	if err == nil {
 		t.Errorf("should fail")
+	}
+}
+
+func TestSigner_LoadSigningInformationFromModernPKCS12(t *testing.T) {
+	// Re-encode the legacy test keystore with modern algorithms (PBES2, AES-256-CBC, SHA-256 MAC),
+	// as OpenSSL 3 exports by default.
+	legacy, err := os.ReadFile(filepath.Join("test", "passbook", "passkit.p12"))
+	if err != nil {
+		t.Fatalf("could not read the legacy keystore. %v", err)
+	}
+	key, cert, _, err := pkcs12.DecodeChain(legacy, "password")
+	if err != nil {
+		t.Fatalf("could not decode the legacy keystore. %v", err)
+	}
+	modern, err := pkcs12.Modern.Encode(key, cert, nil, "password")
+	if err != nil {
+		t.Fatalf("could not encode the modern keystore. %v", err)
+	}
+
+	ca, err := os.ReadFile(filepath.Join("test", "passbook", "ca.pem"))
+	if err != nil {
+		t.Fatalf("could not read the CA file. %v", err)
+	}
+
+	signingInfo, err := LoadSigningInformationFromBytes(modern, "password", ca)
+	if err != nil {
+		t.Fatalf("could not load signing info from a modern keystore. %v", err)
+	}
+
+	passJson, err := os.ReadFile(filepath.Join("test", "pass2.json"))
+	if err != nil {
+		t.Fatalf("could not load pass json file. %v", err)
+	}
+	if _, err := signManifestFile(passJson, signingInfo); err != nil {
+		t.Errorf("could not sign manifest. %v", err)
 	}
 }


### PR DESCRIPTION
This PR goes back to SSLMate's `go-pkcs12` to fix #35. The `x/crypto/pkcs12` package we use is frozen and only reads legacy keystores, so any certificate exported by OpenSSL 3 (PBES2, AES-256, SHA-256 MAC) fails to load unless you re-export it with `-legacy`.

I also added a regression test because the current `passkit.p12` fixture is a legacy keystore and never covered this: it re-encodes the same keystore with `pkcs12.Modern` and then loads it and signs a manifest.

Finally, I took the opportunity to update the libraries to their latest minor/patch versions.